### PR TITLE
Adjust docker file to use go version 1.23.2

### DIFF
--- a/build/images/training-operator/Dockerfile.konflux
+++ b/build/images/training-operator/Dockerfile.konflux
@@ -1,11 +1,11 @@
 ARG SOURCE_CODE=.
 
 # BEGIN -- workaround lack of go-toolset for golang 1.23
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23@sha256:744be415305e1cf3701484b69e41bd67df2e0b728a5804fa170069cec6c9a189 AS golang
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:e5f5973d201e688987434e3a92d531fa62ec2defa0ff04f51c324b7c82e29dc8 AS golang
 
 FROM registry.access.redhat.com/ubi8/ubi@sha256:fd93fc09dc09f3d3edae30577460a979bb52df351b826ef3a5c02ec8213b433a AS builder
 
-ARG GOLANG_VERSION=1.23.0
+ARG GOLANG_VERSION=1.23.2
 
 # Install system dependencies
 RUN dnf upgrade -y && dnf install -y \


### PR DESCRIPTION
**What this PR does / why we need it**:
Latest version of brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 is fecthing go lang 1.23.4.
Go lang 1.23.4 requires glibc library version 2.32 or 2.34, however UBI 8 has just glibc 2.28.
As a workaround, using older openshift-golang-builder image version i.e 1.23.2 (which has compatible `glibc 2.28`)

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**
No user facing changes
- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
