### PR TITLE
Update training-operator dockerfile to add -y flag for microdnf updat…

### DIFF
--- a/build/images/training-operator/Dockerfile.konflux
+++ b/build/images/training-operator/Dockerfile.konflux
@@ -51,7 +51,7 @@ LABEL com.redhat.component="odh-training-operator-container" \
       io.k8s.description="odh-training-operator" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
 
-RUN microdnf update && microdnf install -y bind-utils
+RUN microdnf update -y && microdnf install -y bind-utils
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
 In ubi8 `microdnf update` seems to always be non-interactive, whereas in ubi9 it prompts for input without a `-y`

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
