### PR TITLE
update tekton pipeline git ref revision to release branch

### DIFF
--- a/.tekton/odh-training-operator-v2-21-push.yaml
+++ b/.tekton/odh-training-operator-v2-21-push.yaml
@@ -49,7 +49,7 @@ spec:
     - name: url
       value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
     - name: revision
-      value: main
+      value: rhoai-2.21
     - name: pathInRepo
       value: pipelines/container-build.yaml
   taskRunTemplate: {}


### PR DESCRIPTION
in this PR we are updating the pipeline ref to be used from a release branch, same as the current release branch.

this is an example that the konflux central pipeline's life cycle is the same as the component.