### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-training-operator-v2-19

### DIFF
--- a/build/images/training-operator/Dockerfile.konflux
+++ b/build/images/training-operator/Dockerfile.konflux
@@ -23,7 +23,8 @@ FROM registry.redhat.io/ubi8/ubi-minimal@sha256:43dde01be4e94afd22d8d95ee8abcc9f
 ARG USER=65532
 
 LABEL com.redhat.component="odh-training-operator-container" \
-      name="managed-open-data-hub/odh-training-operator-rhel8" \
+      name="rhoai/odh-training-operator-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.19::el8" \
       description="Training Operator is a Kubernetes-native project for fine-tuning and scalable distributed training of AI/ML models created with various frameworks such as PyTorch." \
       summary="odh-training-operator" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
