### PR TITLE
CVE-2026-32283, CVE-2026-33814: update go-toolset Konflux digest to 1.26

### DIFF
--- a/build/images/training-operator/Dockerfile.konflux
+++ b/build/images/training-operator/Dockerfile.konflux
@@ -1,5 +1,5 @@
 ARG SOURCE_CODE=.
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e as builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:a6ba68b40051fe65e6852c69e4a9496aec2ac28f7ac92431ce2529bae2d105f3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
## Summary
- Update Dockerfile.konflux SHA from go-toolset 1.25 (Go 1.25.9) to go-toolset 1.26 (Go 1.26.4)
- go.mod, hack/swagger/go.mod, and golang.org/x/net already at 1.26.4 / v0.55.0 on main
- Dockerfile.rhoai already at go-toolset:1.26 on main

## CVEs Fixed
- CVE-2026-32283 — crypto/tls DoS
- CVE-2026-33814 — net/http/internal/http2 DoS

🤖 Generated with [Claude Code](https://claude.com/claude-code)